### PR TITLE
Sync to 2.0.3 Tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.project
 /.settings/
 /bin/
+/api/target/
+/spec/target/

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -29,6 +30,10 @@
     <packaging>jar</packaging>
 
     <name>Jakarta Messaging API</name>
+    <description>
+        Jakarta Messaging describes a means for Java applications to create, send, 
+        and receive messages via loosely coupled, reliable asynchronous communication services.
+    </description>
 
     <licenses>
         <license>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -110,6 +110,14 @@
         </pluginManagement>
 
         <resources>
+             <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE.md</include>
+                    <include>NOTICE.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
             <resource>
                 <directory>${project.basedir}</directory>
                 <includes>
@@ -197,39 +205,42 @@
                 </configuration>
             </plugin>
 
+            <!-- 
+               Create Javadoc for API jar
+             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <groups>
-                        <group>
-                            <title>Jakarta Messaging API Documentation</title>
-                            <packages>
-                                javax.jms
-                            </packages>
-                        </group>
-                    </groups>
-
-                    <!-- Specifies the text to be placed at the bottom of each output file. -->
-                    <bottom>Copyright 1997-2018 Oracle America Inc. Copyright 2019 Contributors to the Eclipse Foundation.  All rights reserved.</bottom>
-
-                    <!-- Specifies the header text to be placed at the top of each output file, to the right of the upper navigation bar. -->
-                    <header>Jakarta Messaging ${spec.version}</header>
-
-                    <!-- Specifies the footer text to be placed at the top of each output file, to the right of the lower navigation bar. -->
-                    <footer>Jakarta Messaging ${spec.version}</footer>
-
-                    <links>
-                        <link>https://projects.eclipse.org/projects/ee4j.jms</link>
-                    </links>
-                </configuration>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>attach-api-javadocs</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                     </execution>
+                        <configuration>
+                            <source>1.8</source>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                            <description>Jakarta Messaging API documentation</description>
+                            <doctitle>Jakarta Messaging API documentation</doctitle>
+                            <windowtitle>Jakarta Messaging API documentation</windowtitle>
+                            <header><![CDATA[<br>Jakarta Messaging API v${project.version}]]></header>
+                            <bottom><![CDATA[
+Comments to: <a href="mailto:jms-dev@eclipse.org">jms-dev@eclipse.org</a>.<br>
+Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
+                            </bottom>
+                            <docfilessubdirs>true</docfilessubdirs>
+                            <groups>
+                                <group>
+                                    <title>Jakarta Messaging API Documentation</title>
+                                    <packages>
+                                        javax.jms
+                                    </packages>
+                                </group>
+                            </groups>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/api/src/main/javadoc/doc-files/speclicense.html
+++ b/api/src/main/javadoc/doc-files/speclicense.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+<title>Eclipse Foundation Specification License - v1.0</title>
+</head>
+<body>
+<h1>Eclipse Foundation Specification License - v1.0</h1>
+<p>By using and/or copying this document, or the Eclipse Foundation
+  document from which this statement is linked, you (the licensee) agree
+  that you have read, understood, and will comply with the following
+  terms and conditions:</p>
+
+<p>Permission to copy, and distribute the contents of this document, or
+  the Eclipse Foundation document from which this statement is linked, in
+  any medium for any purpose and without fee or royalty is hereby
+  granted, provided that you include the following on ALL copies of the
+  document, or portions thereof, that you use:</p>
+
+<ul>
+  <li> link or URL to the original Eclipse Foundation document.</li>
+  <li>All existing copyright notices, or if one does not exist, a notice
+      (hypertext is preferred, but a textual representation is permitted)
+      of the form: &quot;Copyright &copy; [$date-of-document]
+      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      &quot;
+  </li>
+</ul>
+
+<p>Inclusion of the full text of this NOTICE must be provided. We
+  request that authorship attribution be provided in any software,
+  documents, or other items or products that you create pursuant to the
+  implementation of the contents of this document, or any portion
+  thereof.</p>
+
+<p>No right to create modifications or derivatives of Eclipse Foundation
+  documents is granted pursuant to this license, except anyone may
+  prepare and distribute derivative works and portions of this document
+  in software that implements the specification, in supporting materials
+  accompanying such software, and in documentation of such software,
+  PROVIDED that all such works include the notice below. HOWEVER, the
+  publication of derivative works of this document for use as a technical
+  specification is expressly prohibited.</p>
+
+<p>The notice is:</p>
+
+<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+  document includes material copied from or derived from [title and URI
+  of the Eclipse Foundation specification document].&quot;</p>
+
+<h2>Disclaimers</h2>
+
+<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
+  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
+  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
+  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
+  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+  OTHER RIGHTS.</p>
+
+<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
+  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
+  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
+  CONTENTS THEREOF.</p>
+
+<p>The name and trademarks of the copyright holders or the Eclipse
+  Foundation may NOT be used in advertising or publicity pertaining to
+  this document or its contents without specific, written prior
+  permission. Title to copyright in this document will at all times
+  remain with copyright holders.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Apply commits to resolve differences in the 'api' directory between the commit before fork-related changes in this branch[1] vs what ended up as the eclipse 2.0.3 tag[2].

[1] https://github.com/jboss/jboss-jakarta-jms-api/commit/ac89a6e4be6acea405096c80f2790bdb87481182 preceding https://github.com/jboss/jboss-jakarta-jms-api/commit/1ae1d9abc1d87eb5fc31a3fb81730608bfad86e6

[2] https://github.com/eclipse-ee4j/jms-api/tree/2.0.3-RELEASE